### PR TITLE
Prepare Redback for MooseVariable::sln() const update.

### DIFF
--- a/include/auxkernels/RedbackTotalPorosityAux.h
+++ b/include/auxkernels/RedbackTotalPorosityAux.h
@@ -23,7 +23,7 @@ protected:
   bool _is_mechanics_on; //, _is_chemistry_on;
 
 private:
-  VariableValue & _delta_porosity_mech;
+  const VariableValue & _delta_porosity_mech;
   // MaterialProperty<Real> & _delta_porosity_mech;
   const MaterialProperty<Real> & _delta_porosity_chem;
   const MaterialProperty<Real> & _initial_porosity;

--- a/include/kernels/RedbackChemPressure.h
+++ b/include/kernels/RedbackChemPressure.h
@@ -33,7 +33,7 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  // VariableValue &_temp;
+  // const VariableValue & _temp;
   const MaterialProperty<Real> & _chemical_source_mass;
   const MaterialProperty<Real> & _chemical_source_mass_jac;
 

--- a/include/kernels/RedbackDamage.h
+++ b/include/kernels/RedbackDamage.h
@@ -33,7 +33,7 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  // VariableValue & _pressure;
+  // const VariableValue & _pressure;
   const MaterialProperty<Real> & _damage_kernel;
   const MaterialProperty<Real> & _damage_kernel_jac;
 

--- a/include/kernels/RedbackMassDiffusion.h
+++ b/include/kernels/RedbackMassDiffusion.h
@@ -32,7 +32,7 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  //  VariableValue & _T;
+  //  const VariableValue & _T;
 
   const MaterialProperty<Real> & _Le;
   const MaterialProperty<RealVectorValue> & _gravity_term;

--- a/include/kernels/RedbackMechDissip.h
+++ b/include/kernels/RedbackMechDissip.h
@@ -33,7 +33,7 @@ protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
 
-  // VariableValue & _pressure;
+  // const VariableValue & _pressure;
   const MaterialProperty<Real> & _mechanical_dissipation;
   const MaterialProperty<Real> & _mechanical_dissipation_jac;
 

--- a/include/kernels/RedbackStressDivergenceTensors.h
+++ b/include/kernels/RedbackStressDivergenceTensors.h
@@ -28,7 +28,7 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  VariableValue & _pore_pres;
+  const VariableValue & _pore_pres;
   RealVectorValue _poromech_stress_row;
 
   const MaterialProperty<RankTwoTensor> & _stress;

--- a/include/kernels/RedbackThermalPressurization.h
+++ b/include/kernels/RedbackThermalPressurization.h
@@ -36,8 +36,8 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  VariableValue & _temp_dot;
-  VariableValue & _dtemp_dot_dtemp;
+  const VariableValue & _temp_dot;
+  const VariableValue & _dtemp_dot_dtemp;
 
   const MaterialProperty<Real> & _pressurization_coefficient;
   unsigned int _temp_var; // variable number of the temperature variable

--- a/include/materials/RedbackMaterial.h
+++ b/include/materials/RedbackMaterial.h
@@ -53,11 +53,11 @@ protected:
   virtual void computeRedbackTerms();
 
   bool _has_T;
-  VariableValue & _T;
+  const VariableValue & _T;
   bool _has_pore_pres;
-  VariableValue & _pore_pres; //, & _pore_pres_old;
-  VariableValue & _total_porosity;
-  VariableValue & _inverse_lewis_number_tilde;
+  const VariableValue & _pore_pres; //, & _pore_pres_old;
+  const VariableValue & _total_porosity;
+  const VariableValue & _inverse_lewis_number_tilde;
 
   // functionality to initialise some parameters from function (overwrites initialisation as float)
   std::vector<std::string> _init_from_functions__params;
@@ -141,9 +141,9 @@ protected:
   VariableGradient & _grad_pore_pressure;
   // VariableSecond& _grad_grad_pore_pressure;
 
-  VariableValue & _dispx_dot;
-  VariableValue & _dispy_dot;
-  VariableValue & _dispz_dot;
+  const VariableValue & _dispx_dot;
+  const VariableValue & _dispy_dot;
+  const VariableValue & _dispz_dot;
   MaterialProperty<RealVectorValue> & _solid_velocity;
 
   Real _T0_param, _P0_param;

--- a/include/materials/RedbackMechMaterial.h
+++ b/include/materials/RedbackMechMaterial.h
@@ -81,7 +81,7 @@ protected:
   /// Current deformation gradient
   // RankTwoTensor _dfgrd;
 
-  // VariableValue & _T;
+  // const VariableValue & _T;
 
   // Copy-paste from FiniteStrainMaterial.h
   MaterialProperty<RankTwoTensor> & _strain_rate;
@@ -147,20 +147,22 @@ protected:
   Real _damage_coeff, _healing_coeff;
 
   Real _exponential;
-  // VariableValue & _dispx_dot;
-  // VariableValue & _dispy_dot;
-  // VariableValue & _dispz_dot;
+  // const VariableValue & _dispx_dot;
+  // const VariableValue & _dispy_dot;
+  // const VariableValue & _dispz_dot;
 
   // MaterialProperty<RealVectorValue> & _solid_velocity;
 
   // Using variables
   bool _has_T;
-  VariableValue &_T, &_T_old;
+  const VariableValue & _T;
+  const VariableValue & _T_old;
   bool _has_pore_pres;
-  VariableValue & _pore_pres;
-  VariableValue & _total_porosity;
+  const VariableValue & _pore_pres;
+  const VariableValue & _total_porosity;
   bool _has_D;
-  VariableValue &_damage, &_damage_old;
+  const VariableValue & _damage;
+  const VariableValue & _damage_old;
 
   DamageMethod _damage_method;
 


### PR DESCRIPTION
This set of changes prepares Redback to work with an upcoming version of
MOOSE in which MooseVariable::sln() returns a const reference.

Refs idaholab/moose#6327.