### PR TITLE
Prepare Redback for coupledGradient() const reference return value.

### DIFF
--- a/include/kernels/RedbackMassConvection.h
+++ b/include/kernels/RedbackMassConvection.h
@@ -16,7 +16,7 @@ protected:
   virtual Real computeQpJacobian();
   virtual Real computeQpOffDiagJacobian(unsigned int jvar);
 
-  VariableGradient & _grad_temp;
+  const VariableGradient & _grad_temp;
 
   const MaterialProperty<RealVectorValue> & _pressure_convective_mass;
   const MaterialProperty<RealVectorValue> & _thermal_convective_mass;

--- a/include/materials/RedbackMaterial.h
+++ b/include/materials/RedbackMaterial.h
@@ -137,8 +137,8 @@ protected:
 
   MaterialProperty<Real> & _pressurization_coefficient;
 
-  VariableGradient & _grad_temp;
-  VariableGradient & _grad_pore_pressure;
+  const VariableGradient & _grad_temp;
+  const VariableGradient & _grad_pore_pressure;
   // VariableSecond& _grad_grad_pore_pressure;
 
   const VariableValue & _dispx_dot;

--- a/include/materials/RedbackMechMaterial.h
+++ b/include/materials/RedbackMechMaterial.h
@@ -58,13 +58,13 @@ protected:
   virtual void computeQpStress();
   virtual void initQpStatefulProperties(); // from FiniteStrainMaterial.h
 
-  VariableGradient & _grad_disp_x;
-  VariableGradient & _grad_disp_y;
-  VariableGradient & _grad_disp_z;
+  const VariableGradient & _grad_disp_x;
+  const VariableGradient & _grad_disp_y;
+  const VariableGradient & _grad_disp_z;
 
-  VariableGradient & _grad_disp_x_old;
-  VariableGradient & _grad_disp_y_old;
-  VariableGradient & _grad_disp_z_old;
+  const VariableGradient & _grad_disp_x_old;
+  const VariableGradient & _grad_disp_y_old;
+  const VariableGradient & _grad_disp_z_old;
 
   MaterialProperty<RankTwoTensor> & _stress;
   MaterialProperty<RankTwoTensor> & _total_strain;


### PR DESCRIPTION
This set of changes prepares Redback to work with an upcoming version of
MOOSE in which coupledGradient() returns a const reference.

Refs idaholab/moose#6327.

Follow-on to work in 3d3ccaf.