### PR TITLE
Petsc 3.7 updates

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+Manolis Veveakis <vev001@csiro.au>
+Manolis Veveakis <manolis@manos.ad.unsw.edu.au>
+Jack Lin <jack_lin@zoho.com>
+Hadrien Rattez <hrattez@gmail.com>
+Martin Paesold <martin@ECM-DTC-088.local>
+Martin Lesueur <martin.lesueur@ecl2015.ec-lyon.fr>
+Mustafa Sari <ptrl_sari@hotmail.com>
+Manman Hu <manman.hu@unsw.edu.au>

--- a/tests/gravity/gravity_horizontal.cmp
+++ b/tests/gravity/gravity_horizontal.cmp
@@ -1,0 +1,15 @@
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:           2e-06 @ t21
+
+GLOBAL VARIABLES relative 1.e-6 floor 0.0
+	dt               # min:               0 @ t1	max:           1e-07 @ t2
+	middle_porosity  # min:               0 @ t1	max:             0.3 @ t2
+	middle_press     # min:               0 @ t1	max:      0.99999746 @ t21
+	num_li           relative 0.5 # min:               0 @ t1	max:               6 @ t20
+	num_nli          # min:               0 @ t1	max:               2 @ t2
+
+NODAL VARIABLES relative 1.e-6 floor 0.0
+	pore_pressure   # min:               0 @ t1,n1	max:       1.9799964 @ t21,n15
+	total_porosity  # min:               0 @ t1,n1	max:             0.3 @ t2,n7
+

--- a/tests/gravity/gravity_vertical.cmp
+++ b/tests/gravity/gravity_vertical.cmp
@@ -1,0 +1,14 @@
+COORDINATES absolute 1.e-6    # min separation not calculated
+
+TIME STEPS relative 1.e-6 floor 0.0     # min:               0 @ t1 max:           2e-06 @ t21
+
+GLOBAL VARIABLES relative 1.e-6 floor 0.0
+	dt               # min:               0 @ t1	max:           1e-07 @ t2
+	middle_porosity  # min:               0 @ t1	max:             0.3 @ t2
+	middle_press     # min:               0 @ t1	max:            0.51 @ t21
+	num_li           relative 0.5 # min:               0 @ t1	max:               6 @ t2
+	num_nli          relative 0.5 # min:               0 @ t1	max:               2 @ t2
+
+NODAL VARIABLES relative 1.e-6 floor 0.0
+	pore_pressure   # min:               0 @ t1,n1	max:               1 @ t21,n1
+	total_porosity  # min:               0 @ t1,n1	max:             0.3 @ t2,n7

--- a/tests/gravity/tests
+++ b/tests/gravity/tests
@@ -3,11 +3,19 @@
     type = 'Exodiff'
     input = 'gravity_horizontal.i'
     exodiff = 'gravity_horizontal.e'
+    # The custom comparison file allows variations in the number of
+    # linear and nonlinear iterations, which can vary between versions
+    # of PETSc.
+    custom_cmp = 'gravity_horizontal.cmp'
   [../]
   [./test_gravity_vertical] # can't put a dot in that name!
     type = 'Exodiff'
     input = 'gravity_vertical.i'
     exodiff = 'gravity_vertical.e'
+    # The custom comparison file allows variations in the number of
+    # linear and nonlinear iterations, which can vary between versions
+    # of PETSc.
+    custom_cmp = 'gravity_vertical.cmp'
   [../]
   [./test_rho_g_h] # can't put a dot in that name!
     # Testing geostatic gradient rho * g * h only


### PR DESCRIPTION
Two tests (gravity_vertical and gravity_horizontal) take a slightly different number of iterations in new PETSc, and this causes a diff. I think this is pretty normal when changing from one version of PETSc to another, so I just loosened the tolerances on the num_li and num_nli variables a bit, and they now pass.