### PR TITLE
Skipping subset of tests with memory errors on Linux Platform

### DIFF
--- a/tests/benchmark_10_TMC/tests
+++ b/tests/benchmark_10_TMC/tests
@@ -1,20 +1,26 @@
+# None of these tests are Valgrind clean and fail randomly
+# when tested on Linux system. See discussion in #132.
+
 [Tests]
   [./test_10_TMC_J2] # can't put a dot in that name!
     type = 'Exodiff'
     input = 'bench_TMC_J2.i'
     exodiff = 'bench_TMC_J2_out.e'
     rel_err = 1e-4
+    platform = '!LINUX'
   [../]
   [./test_10_TMC_DP] # can't put a dot in that name!
     type = 'Exodiff'
     input = 'bench_TMC_DP.i'
     exodiff = 'bench_TMC_DP_out.e'
     rel_err = 1e-3
+    platform = '!LINUX'
   [../]
   [./test_10_TMC_CC] # can't put a dot in that name!
     type = 'Exodiff'
     input = 'bench_TMC_CC.i'
     exodiff = 'bench_TMC_CC_out.e'
     rel_err = 1e-4
+    platform = '!LINUX'
   [../]
 []

--- a/tests/benchmark_11_THMC/tests
+++ b/tests/benchmark_11_THMC/tests
@@ -1,20 +1,26 @@
+# None of these tests are Valgrind clean and fail randomly
+# when tested on Linux system. See discussion in #132.
+
 [Tests]
   [./test_11_THMC_J2] # can't put a dot in that name!
     type = 'Exodiff'
     input = 'bench_THMC_J2.i'
     exodiff = 'bench_THMC_J2_out.e'
     rel_err = 1e-4
+    platform = '!LINUX'
   [../]
   [./test_11_THMC_DP] # can't put a dot in that name!
     type = 'Exodiff'
     input = 'bench_THMC_DP.i'
     exodiff = 'bench_THMC_DP_out.e'
     rel_err = 1e-4
+    platform = '!LINUX'
   [../]
   [./test_11_THMC_CC] # can't put a dot in that name!
     type = 'Exodiff'
     input = 'bench_THMC_CC.i'
     exodiff = 'bench_THMC_CC_out.e'
     rel_err = 1e-4
+    platform = '!LINUX'
   [../]
 []


### PR DESCRIPTION
This skips several tests on Linux that fail randomly in our CIVET testing. Please merge until they can be addressed and verified.

Thanks!