### PR TITLE
One more test failing (not valgrind clean)

### DIFF
--- a/tests/benchmark_6_TM/tests
+++ b/tests/benchmark_6_TM/tests
@@ -16,6 +16,7 @@
     input = 'bench_TM_CC.i'
     exodiff = 'bench_TM_CC_out.e'
     rel_err = 1e-6
+    skip = "Not valgrind clean"
   [../]
   [./test_6_TM_thermo_elastic] # can't put a dot in that name!
     type = 'CSVDiff'


### PR DESCRIPTION
refs #132 

With yesterday's libMesh update, we've managed to tip one more test over into sporadic failure land. I suspect that this could happen to even more tests until these valgrind issues are fixed.