### PR TITLE
#43 objects registration done locally (instead of base/RedbackApp.C)

### DIFF
--- a/include/actions/RankTwoScalarAction.h
+++ b/include/actions/RankTwoScalarAction.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/actions/RedbackAction.h
+++ b/include/actions/RedbackAction.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKACTION_H
 #define REDBACKACTION_H
 

--- a/include/actions/RedbackMechAction.h
+++ b/include/actions/RedbackMechAction.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKMECHACTION_H
 #define REDBACKMECHACTION_H
 

--- a/include/auxkernels/RedbackContinuationTangentAux.h
+++ b/include/auxkernels/RedbackContinuationTangentAux.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/auxkernels/RedbackDiffVarsAux.h
+++ b/include/auxkernels/RedbackDiffVarsAux.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKDIFFVARSAUX_H
 #define REDBACKDIFFVARSAUX_H
 

--- a/include/auxkernels/RedbackPolarTensorMaterialAux.h
+++ b/include/auxkernels/RedbackPolarTensorMaterialAux.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKPOLARTENSORMATERIALAUX_H
 #define REDBACKPOLARTENSORMATERIALAUX_H
 

--- a/include/auxkernels/RedbackTotalPorosityAux.h
+++ b/include/auxkernels/RedbackTotalPorosityAux.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKTOTALPOROSITYAUX_H
 #define REDBACKTOTALPOROSITYAUX_H
 

--- a/include/base/RedbackApp.h
+++ b/include/base/RedbackApp.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKAPP_H
 #define REDBACKAPP_H
 
@@ -15,7 +27,7 @@ public:
   virtual ~RedbackApp();
 
   static void registerApps();
-  static void registerObjects(Factory & factory);
+  static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
   static void associateSyntax(Syntax & syntax, ActionFactory & action_factory);
 };
 

--- a/include/bcs/DarcyFluxBC.h
+++ b/include/bcs/DarcyFluxBC.h
@@ -1,11 +1,14 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #ifndef DARCYFLUXBC_H
 #define DARCYFLUXBC_H

--- a/include/bcs/FunctionDirichletTransverseBC.h
+++ b/include/bcs/FunctionDirichletTransverseBC.h
@@ -1,4 +1,15 @@
 /****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+/****************************************************************/
 /* Dirichlet boundary condition to impose displacement in a     */
 /* direction transversal to element normal vector, by taking a  */
 /* vectorial product of the normal with a given vector          */

--- a/include/bcs/MatchedValueJumpBC.h
+++ b/include/bcs/MatchedValueJumpBC.h
@@ -1,11 +1,14 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #ifndef MATCHEDVALUEJUMPBC_H
 #define MATCHEDVALUEJUMPBC_H

--- a/include/bcs/PressureNeumannBC.h
+++ b/include/bcs/PressureNeumannBC.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/ics/FunctionWithRandomIC.h
+++ b/include/ics/FunctionWithRandomIC.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/interfacekernels/InterfaceDarcy.h
+++ b/include/interfacekernels/InterfaceDarcy.h
@@ -1,11 +1,14 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #ifndef INTERFACEDARCY_H
 #define INTERFACEDARCY_H

--- a/include/interfacekernels/InterfaceStress.h
+++ b/include/interfacekernels/InterfaceStress.h
@@ -1,11 +1,14 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #ifndef INTERFACESTRESS_H
 #define INTERFACESTRESS_H

--- a/include/kernels/RedbackChemEndo.h
+++ b/include/kernels/RedbackChemEndo.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackChemExo.h
+++ b/include/kernels/RedbackChemExo.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackChemPressure.h
+++ b/include/kernels/RedbackChemPressure.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackDamage.h
+++ b/include/kernels/RedbackDamage.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackFluidDivergence.h
+++ b/include/kernels/RedbackFluidDivergence.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackFluidStressDivergenceTensors.h
+++ b/include/kernels/RedbackFluidStressDivergenceTensors.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKFLUIDSTRESSDIVERGENCETENSORS_H
 #define REDBACKFLUIDSTRESSDIVERGENCETENSORS_H
 

--- a/include/kernels/RedbackMassConvection.h
+++ b/include/kernels/RedbackMassConvection.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKMASSCONVECTION_H
 #define REDBACKMASSCONVECTION_H
 

--- a/include/kernels/RedbackMassDiffusion.h
+++ b/include/kernels/RedbackMassDiffusion.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackMechDissip.h
+++ b/include/kernels/RedbackMechDissip.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackNavier.h
+++ b/include/kernels/RedbackNavier.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackPoromechanics.h
+++ b/include/kernels/RedbackPoromechanics.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackStressDivergenceTensors.h
+++ b/include/kernels/RedbackStressDivergenceTensors.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKSTRESSDIVERGENCETENSORS_H
 #define REDBACKSTRESSDIVERGENCETENSORS_H
 

--- a/include/kernels/RedbackThermalConvection.h
+++ b/include/kernels/RedbackThermalConvection.h
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #ifndef REDBACKTHERMALCONVECTION_H
 #define REDBACKTHERMALCONVECTION_H
 

--- a/include/kernels/RedbackThermalDiffusion.h
+++ b/include/kernels/RedbackThermalDiffusion.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackThermalPressurization.h
+++ b/include/kernels/RedbackThermalPressurization.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/kernels/RedbackVariableEqualsFunction.h
+++ b/include/kernels/RedbackVariableEqualsFunction.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/ComputePlasticStrainRate.h
+++ b/include/materials/ComputePlasticStrainRate.h
@@ -1,9 +1,15 @@
 /****************************************************************/
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*          All contents are licensed under LGPL V2.1           */
-/*             See LICENSE for full restrictions                */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #ifndef COMPUTEPLASTICSTRAINRATE_H
 #define COMPUTEPLASTICSTRAINRATE_H
 

--- a/include/materials/ImageProcessing.h
+++ b/include/materials/ImageProcessing.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackFluidMaterial.h
+++ b/include/materials/RedbackFluidMaterial.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackMaterial.h
+++ b/include/materials/RedbackMaterial.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackMechMaterial.h
+++ b/include/materials/RedbackMechMaterial.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackMechMaterialCC.h
+++ b/include/materials/RedbackMechMaterialCC.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackMechMaterialCCanisotropic.h
+++ b/include/materials/RedbackMechMaterialCCanisotropic.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackMechMaterialDP.h
+++ b/include/materials/RedbackMechMaterialDP.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackMechMaterialElastic.h
+++ b/include/materials/RedbackMechMaterialElastic.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackMechMaterialExpCC.h
+++ b/include/materials/RedbackMechMaterialExpCC.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/materials/RedbackMechMaterialJ2.h
+++ b/include/materials/RedbackMechMaterialJ2.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/meshmodifiers/ElementFileSubdomain.h
+++ b/include/meshmodifiers/ElementFileSubdomain.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/include/postprocessors/RankTwoScalarPostprocessor.h
+++ b/include/postprocessors/RankTwoScalarPostprocessor.h
@@ -1,16 +1,15 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #ifndef RANKTWOSCALARPOSTPROCESSOR_H
 #define RANKTWOSCALARPOSTPROCESSOR_H
 

--- a/include/timesteppers/ReturnMapIterDT.h
+++ b/include/timesteppers/ReturnMapIterDT.h
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/

--- a/src/actions/RankTwoScalarAction.C
+++ b/src/actions/RankTwoScalarAction.C
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
@@ -17,6 +15,8 @@
 #include "Parser.h"
 #include "RankTwoScalarAction.h"
 #include "RankTwoScalarTools.h"
+
+registerMooseAction("RedbackApp", RankTwoScalarAction, "add_postprocessor");
 
 template <>
 InputParameters

--- a/src/actions/RedbackAction.C
+++ b/src/actions/RedbackAction.C
@@ -1,3 +1,15 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #include "RedbackAction.h"
 
 #include "FEProblem.h"

--- a/src/actions/RedbackMechAction.C
+++ b/src/actions/RedbackMechAction.C
@@ -1,8 +1,22 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #include "RedbackMechAction.h"
 
 #include "FEProblem.h"
 #include "Factory.h"
 #include "Parser.h"
+
+registerMooseAction("RedbackApp", RedbackMechAction, "add_kernel");
 
 template <>
 InputParameters
@@ -41,86 +55,89 @@ RedbackMechAction::RedbackMechAction(InputParameters params)
 void
 RedbackMechAction::act()
 {
-  // Determine whether RZ
-  bool rz = false;
-  unsigned int dim = 1;
-  std::vector<std::string> keys;
-  std::vector<VariableName> vars;
-  std::string type("RedbackStressDivergenceTensors");
-
-  /* if (_problem->coordSystem() == Moose::COORD_RZ)
+  if (_current_task == "add_kernel")
   {
-    rz = true;
-    dim = 2;
-    keys.push_back("disp_r");
-    keys.push_back("disp_z");
-    vars.push_back(_disp_r);
-    vars.push_back(_disp_z);
-    type = "StressDivergenceRZ";
-    }*/
+    // Determine whether RZ
+    bool rz = false;
+    unsigned int dim = 1;
+    std::vector<std::string> keys;
+    std::vector<VariableName> vars;
+    std::string type("RedbackStressDivergenceTensors");
 
-  if (!rz && _disp_x == "")
-    mooseError("disp_x must be specified");
-
-  if (!rz)
-  {
-    keys.push_back("disp_x");
-    vars.push_back(_disp_x);
-    if (_disp_y != "")
+    /* if (_problem->coordSystem() == Moose::COORD_RZ)
     {
-      ++dim;
-      keys.push_back("disp_y");
-      vars.push_back(_disp_y);
-      if (_disp_z != "")
+      rz = true;
+      dim = 2;
+      keys.push_back("disp_r");
+      keys.push_back("disp_z");
+      vars.push_back(_disp_r);
+      vars.push_back(_disp_z);
+      type = "StressDivergenceRZ";
+      }*/
+
+    if (!rz && _disp_x == "")
+      mooseError("disp_x must be specified");
+
+    if (!rz)
+    {
+      keys.push_back("disp_x");
+      vars.push_back(_disp_x);
+      if (_disp_y != "")
       {
         ++dim;
-        keys.push_back("disp_z");
-        vars.push_back(_disp_z);
+        keys.push_back("disp_y");
+        vars.push_back(_disp_y);
+        if (_disp_z != "")
+        {
+          ++dim;
+          keys.push_back("disp_z");
+          vars.push_back(_disp_z);
+        }
       }
     }
-  }
 
-  unsigned int num_coupled(dim);
-  if (_temp != "")
-  {
-    ++num_coupled;
-    keys.push_back("temp");
-    vars.push_back(_temp);
-  }
-  if (_pore_pres != "")
-  {
-    ++num_coupled;
-    keys.push_back("pore_pres");
-    vars.push_back(_pore_pres);
-  }
+    unsigned int num_coupled(dim);
+    if (_temp != "")
+    {
+      ++num_coupled;
+      keys.push_back("temp");
+      vars.push_back(_temp);
+    }
+    if (_pore_pres != "")
+    {
+      ++num_coupled;
+      keys.push_back("pore_pres");
+      vars.push_back(_pore_pres);
+    }
 
-  // Create divergence objects
-  std::string short_name(_name);
-  // Chop off "TensorMechanics/"
-  short_name.erase(0, 15);
+    // Create divergence objects
+    std::string short_name(_name);
+    // Chop off "TensorMechanics/"
+    short_name.erase(0, 15);
 
-  InputParameters params = _factory.getValidParams(type);
-  for (unsigned int j = 0; j < num_coupled; ++j)
-  {
-    params.addCoupledVar(keys[j], "");
-    params.set<std::vector<VariableName>>(keys[j]) = std::vector<VariableName>(1, vars[j]);
-  }
+    InputParameters params = _factory.getValidParams(type);
+    for (unsigned int j = 0; j < num_coupled; ++j)
+    {
+      params.addCoupledVar(keys[j], "");
+      params.set<std::vector<VariableName>>(keys[j]) = std::vector<VariableName>(1, vars[j]);
+    }
 
-  params.set<bool>("use_displaced_mesh") = getParam<bool>("use_displaced_mesh");
-  params.set<std::string>("appended_property_name") =
-      getParam<std::string>("appended_property_name");
+    params.set<bool>("use_displaced_mesh") = getParam<bool>("use_displaced_mesh");
+    params.set<std::string>("appended_property_name") =
+        getParam<std::string>("appended_property_name");
 
-  for (unsigned int i = 0; i < dim; ++i)
-  {
-    std::stringstream name;
-    name << "Kernels/";
-    name << short_name;
-    name << i;
+    for (unsigned int i = 0; i < dim; ++i)
+    {
+      std::stringstream name;
+      name << "Kernels/";
+      name << short_name;
+      name << i;
 
-    params.set<std::vector<SubdomainName>>("block") = _subdomain_names;
-    params.set<unsigned int>("component") = i;
-    params.set<NonlinearVariableName>("variable") = vars[i];
+      params.set<std::vector<SubdomainName>>("block") = _subdomain_names;
+      params.set<unsigned int>("component") = i;
+      params.set<NonlinearVariableName>("variable") = vars[i];
 
-    _problem->addKernel(type, name.str(), params);
+      _problem->addKernel(type, name.str(), params);
+    }
   }
 }

--- a/src/auxkernels/RedbackContinuationTangentAux.C
+++ b/src/auxkernels/RedbackContinuationTangentAux.C
@@ -1,19 +1,19 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
 #include "MooseMesh.h"
 #include "RedbackContinuationTangentAux.h"
+
+registerMooseObject("RedbackApp", RedbackContinuationTangentAux);
 
 template <>
 InputParameters

--- a/src/auxkernels/RedbackDiffVarsAux.C
+++ b/src/auxkernels/RedbackDiffVarsAux.C
@@ -13,6 +13,8 @@
 // AuxKernel to compute difference of 2 (aux)variables
 #include "RedbackDiffVarsAux.h"
 
+registerMooseObject("RedbackApp", RedbackDiffVarsAux);
+
 template <>
 InputParameters
 validParams<RedbackDiffVarsAux>()

--- a/src/auxkernels/RedbackPolarTensorMaterialAux.C
+++ b/src/auxkernels/RedbackPolarTensorMaterialAux.C
@@ -12,6 +12,8 @@
 
 #include "RedbackPolarTensorMaterialAux.h"
 
+registerMooseObject("RedbackApp", RedbackPolarTensorMaterialAux);
+
 template <>
 InputParameters
 validParams<RedbackPolarTensorMaterialAux>()

--- a/src/auxkernels/RedbackTotalPorosityAux.C
+++ b/src/auxkernels/RedbackTotalPorosityAux.C
@@ -12,6 +12,8 @@
 
 #include "RedbackTotalPorosityAux.h"
 
+registerMooseObject("RedbackApp", RedbackTotalPorosityAux);
+
 template <>
 InputParameters
 validParams<RedbackTotalPorosityAux>()

--- a/src/base/RedbackApp.C
+++ b/src/base/RedbackApp.C
@@ -9,90 +9,21 @@
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 // Main Application
-#include "ActionFactory.h"
-#include "AppFactory.h"
-#include "Moose.h"
-#include "MooseSyntax.h"
 #include "RedbackApp.h"
+#include "Moose.h"
+#include "AppFactory.h"
+#include "ModulesApp.h"
+#include "MooseSyntax.h"
 
 // Modules
 #include "TensorMechanicsApp.h"
 
 // Actions
-#include "RankTwoScalarAction.h"
-#include "RedbackAction.h"
-#include "RedbackMechAction.h"
-
-// Boundary conditions
-#include "DarcyFluxBC.h"
-#include "FunctionDirichletTransverseBC.h"
-#include "MatchedValueJumpBC.h"
-#include "PressureNeumannBC.h"
-
-// Functions
-#include "RedbackRandomFunction.h"
-
-// Initial conditions
-#include "FunctionLogNormalDistributionIC.h"
-#include "FunctionNormalDistributionIC.h"
-#include "FunctionTimesRandomIC.h"
-#include "FunctionWithRandomIC.h"
-
-// Interface kernels
-#include "InterfaceDarcy.h"
-#include "InterfaceStress.h"
-
-// Kernels
-#include "RedbackChemEndo.h"
-#include "RedbackChemExo.h"
-#include "RedbackChemPressure.h"
-#include "RedbackDamage.h"
-#include "RedbackFluidDivergence.h"
-#include "RedbackFluidStressDivergenceTensors.h"
-#include "RedbackMassConvection.h"
-#include "RedbackMassDiffusion.h"
-#include "RedbackMechDissip.h"
-#include "RedbackNavier.h"
-#include "RedbackPoromechanics.h"
-#include "RedbackStressDivergenceTensors.h"
-#include "RedbackThermalConvection.h"
-#include "RedbackThermalDiffusion.h"
-#include "RedbackThermalPressurization.h"
-#include "RedbackVariableEqualsFunction.h"
-
-// Scalar Kernels
-#include "RedbackContinuation.h"
-
-// Dirac Kernels
-#include "FunctionPointSource.h"
-
-// Materials
-#include "ComputePlasticStrainRate.h"
-#include "ImageProcessing.h"
-#include "RedbackFluidMaterial.h"
-#include "RedbackMaterial.h"
-#include "RedbackMechMaterialCC.h"
-#include "RedbackMechMaterialCCanisotropic.h"
-#include "RedbackMechMaterialDP.h"
-#include "RedbackMechMaterialElastic.h"
-#include "RedbackMechMaterialExpCC.h"
-#include "RedbackMechMaterialJ2.h"
-
-// MeshModifiers
-#include "ElementFileSubdomain.h"
-
-// Postprocessors
-#include "RankTwoScalarPostprocessor.h"
-
-// Timesteppers
-#include "ReturnMapIterDT.h"
-
-// AuxKernels
-#include "RedbackContinuationTangentAux.h"
-#include "RedbackDiffVarsAux.h"
-#include "RedbackPolarTensorMaterialAux.h"
-#include "RedbackTotalPorosityAux.h"
+//#include "RankTwoScalarAction.h"
+//#include "RedbackAction.h"
+//#include "RedbackMechAction.h"
 
 template <>
 InputParameters
@@ -104,106 +35,48 @@ validParams<RedbackApp>()
 
 RedbackApp::RedbackApp(InputParameters parameters) : MooseApp(parameters)
 {
-  srand(processor_id());
-
-  Moose::registerObjects(_factory);
-  TensorMechanicsApp::registerObjects(_factory);
-  RedbackApp::registerObjects(_factory);
-
-  Moose::associateSyntax(_syntax, _action_factory);
-  TensorMechanicsApp::associateSyntax(_syntax, _action_factory);
-  RedbackApp::associateSyntax(_syntax, _action_factory);
+  RedbackApp::registerAll(_factory, _action_factory, _syntax);
 }
 
 RedbackApp::~RedbackApp() {}
 
 void
-RedbackApp::registerApps()
+RedbackApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
 {
-#undef registerApp
-#define registerApp(name) AppFactory::instance().reg<name>(#name)
-  registerApp(RedbackApp);
-#undef registerApp
-#define registerApp(name) AppFactory::instance().regLegacy<name>(#name)
-}
+  Registry::registerObjectsTo(f, {"RedbackApp"});
+  Registry::registerActionsTo(af, {"RedbackApp"});
 
-void
-RedbackApp::registerObjects(Factory & factory)
-{
-#undef registerObject
-#define registerObject(name) factory.reg<name>(stringifyName(name))
-  registerBoundaryCondition(DarcyFluxBC);
-  registerBoundaryCondition(FunctionDirichletTransverseBC);
-  registerBoundaryCondition(MatchedValueJumpBC);
-  registerBoundaryCondition(PressureNeumannBC);
+  ModulesApp::registerAll(f, af, s);
 
-  registerFunction(RedbackRandomFunction);
-
-  registerInitialCondition(FunctionNormalDistributionIC);
-  registerInitialCondition(FunctionLogNormalDistributionIC);
-  registerInitialCondition(FunctionWithRandomIC);
-  registerInitialCondition(FunctionTimesRandomIC);
-
-  registerInterfaceKernel(InterfaceDarcy);
-  registerInterfaceKernel(InterfaceStress);
-
-  registerKernel(RedbackChemEndo);
-  registerKernel(RedbackChemExo);
-  registerKernel(RedbackChemPressure);
-  registerKernel(RedbackFluidDivergence);
-  registerKernel(RedbackFluidStressDivergenceTensors);
-  registerKernel(RedbackMassConvection);
-  registerKernel(RedbackMassDiffusion);
-  registerKernel(RedbackMechDissip);
-  registerKernel(RedbackNavier);
-  registerKernel(RedbackPoromechanics);
-  registerKernel(RedbackStressDivergenceTensors);
-  registerKernel(RedbackThermalConvection);
-  registerKernel(RedbackThermalDiffusion);
-  registerKernel(RedbackThermalPressurization);
-  registerKernel(RedbackDamage);
-  registerKernel(RedbackVariableEqualsFunction);
-
-  registerScalarKernel(RedbackContinuation);
-
-  registerDiracKernel(FunctionPointSource);
-
-  registerMaterial(ComputePlasticStrainRate);
-  registerMaterial(RedbackFluidMaterial);
-  registerMaterial(ImageProcessing);
-  registerMaterial(RedbackMaterial);
-  registerMaterial(RedbackMechMaterialJ2);
-  registerMaterial(RedbackMechMaterialDP);
-  registerMaterial(RedbackMechMaterialCC);
-  registerMaterial(RedbackMechMaterialCCanisotropic);
-  registerMaterial(RedbackMechMaterialElastic);
-  registerMaterial(RedbackMechMaterialExpCC);
-
-  registerMeshModifier(ElementFileSubdomain);
-
-  registerPostprocessor(RankTwoScalarPostprocessor);
-
-  registerExecutioner(ReturnMapIterDT);
-
-  registerAux(RedbackContinuationTangentAux);
-  registerAux(RedbackDiffVarsAux);
-  registerAux(RedbackTotalPorosityAux);
-  registerAux(RedbackPolarTensorMaterialAux);
-#undef registerObject
-#define registerObject(name) factory.regLegacy<name>(stringifyName(name))
+  /* register custom execute flags, action syntax, etc. here */
+  RedbackApp::associateSyntax(s, af);
 }
 
 void
 RedbackApp::associateSyntax(Syntax & syntax, ActionFactory & action_factory)
 {
-#undef registerAction
-#define registerAction(tplt, action) action_factory.reg<tplt>(stringifyName(tplt), action)
-  syntax.registerActionSyntax("RankTwoScalarAction", "RankTwoScalarAction/*");
-  registerAction(RankTwoScalarAction, "add_postprocessor");
-  syntax.registerActionSyntax("RedbackMechAction", "RedbackMechAction/*");
-  registerAction(RedbackMechAction, "add_kernel");
-// syntax.registerActionSyntax("RedbackAction", "RedbackAction/*");
-// registerAction(RedbackMechAction, "add_aux_variable");
-#undef registerAction
-#define registerAction(tplt, action) action_factory.regLegacy<tplt>(stringifyName(tplt), action)
+  Registry::registerActionsTo(action_factory, {"RedbackApp"});
+
+  registerSyntax("RankTwoScalarAction", "RankTwoScalarAction/*");
+  registerSyntax("RedbackMechAction", "RedbackMechAction/*");
+}
+
+void
+RedbackApp::registerApps()
+{
+  registerApp(RedbackApp);
+}
+
+/***************************************************************************************************
+ *********************** Dynamic Library Entry Points - DO NOT MODIFY ******************************
+ **************************************************************************************************/
+extern "C" void
+RedbackApp__registerAll(Factory & f, ActionFactory & af, Syntax & s)
+{
+  RedbackApp::registerAll(f, af, s);
+}
+extern "C" void
+RedbackApp__registerApps()
+{
+  RedbackApp::registerApps();
 }

--- a/src/bcs/DarcyFluxBC.C
+++ b/src/bcs/DarcyFluxBC.C
@@ -1,13 +1,18 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #include "DarcyFluxBC.h"
+
+registerMooseObject("RedbackApp", DarcyFluxBC);
 
 template <>
 InputParameters

--- a/src/bcs/FunctionDirichletTransverseBC.C
+++ b/src/bcs/FunctionDirichletTransverseBC.C
@@ -1,4 +1,15 @@
 /****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+/****************************************************************/
 /* Dirichlet boundary condition to impose displacement in a     */
 /* direction transversal to element normal vector, by taking a  */
 /* vectorial product of the normal with a given vector          */
@@ -6,6 +17,8 @@
 
 #include "Function.h"
 #include "FunctionDirichletTransverseBC.h"
+
+registerMooseObject("RedbackApp", FunctionDirichletTransverseBC);
 
 template <>
 InputParameters

--- a/src/bcs/MatchedValueJumpBC.C
+++ b/src/bcs/MatchedValueJumpBC.C
@@ -1,13 +1,18 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #include "MatchedValueJumpBC.h"
+
+registerMooseObject("RedbackApp", MatchedValueJumpBC);
 
 template <>
 InputParameters

--- a/src/bcs/PressureNeumannBC.C
+++ b/src/bcs/PressureNeumannBC.C
@@ -1,18 +1,18 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
 #include "PressureNeumannBC.h"
+
+registerMooseObject("RedbackApp", PressureNeumannBC);
 
 template <>
 InputParameters

--- a/src/dirackernels/FunctionPointSource.C
+++ b/src/dirackernels/FunctionPointSource.C
@@ -13,6 +13,8 @@
 #include "Function.h"
 #include "FunctionPointSource.h"
 
+registerMooseObject("RedbackApp", FunctionPointSource);
+
 template <>
 InputParameters
 validParams<FunctionPointSource>()

--- a/src/functions/RedbackRandomFunction.C
+++ b/src/functions/RedbackRandomFunction.C
@@ -13,6 +13,8 @@
 #include "MooseRandom.h"
 #include "RedbackRandomFunction.h"
 
+registerMooseObject("RedbackApp", RedbackRandomFunction);
+
 template <>
 InputParameters
 validParams<RedbackRandomFunction>()

--- a/src/ics/FunctionLogNormalDistributionIC.C
+++ b/src/ics/FunctionLogNormalDistributionIC.C
@@ -16,6 +16,8 @@
 
 #include "libmesh/point.h"
 
+registerMooseObject("RedbackApp", FunctionLogNormalDistributionIC);
+
 template <>
 InputParameters
 validParams<FunctionLogNormalDistributionIC>()

--- a/src/ics/FunctionNormalDistributionIC.C
+++ b/src/ics/FunctionNormalDistributionIC.C
@@ -16,6 +16,8 @@
 
 #include "libmesh/point.h"
 
+registerMooseObject("RedbackApp", FunctionNormalDistributionIC);
+
 template <>
 InputParameters
 validParams<FunctionNormalDistributionIC>()

--- a/src/ics/FunctionTimesRandomIC.C
+++ b/src/ics/FunctionTimesRandomIC.C
@@ -16,6 +16,8 @@
 
 #include "libmesh/point.h"
 
+registerMooseObject("RedbackApp", FunctionTimesRandomIC);
+
 template <>
 InputParameters
 validParams<FunctionTimesRandomIC>()

--- a/src/ics/FunctionWithRandomIC.C
+++ b/src/ics/FunctionWithRandomIC.C
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
@@ -17,6 +15,8 @@
 #include "MooseRandom.h"
 
 #include "libmesh/point.h"
+
+registerMooseObject("RedbackApp", FunctionWithRandomIC);
 
 template <>
 InputParameters

--- a/src/interfacekernels/InterfaceDarcy.C
+++ b/src/interfacekernels/InterfaceDarcy.C
@@ -1,16 +1,21 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #include "InterfaceDarcy.h"
 #include "MooseVariable.h"
 
 #include <cmath>
+
+registerMooseObject("RedbackApp", InterfaceDarcy);
 
 template <>
 InputParameters

--- a/src/interfacekernels/InterfaceStress.C
+++ b/src/interfacekernels/InterfaceStress.C
@@ -1,16 +1,21 @@
-//* This file is part of the MOOSE framework
-//* https://www.mooseframework.org
-//*
-//* All rights reserved, see COPYRIGHT for full restrictions
-//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
-//*
-//* Licensed under LGPL 2.1, please see LICENSE for details
-//* https://www.gnu.org/licenses/lgpl-2.1.html
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 
 #include "InterfaceStress.h"
 #include "RankTwoScalarTools.h"
 #include "RankTwoTensor.h"
 #include <cmath>
+
+registerMooseObject("RedbackApp", InterfaceStress);
 
 template <>
 InputParameters

--- a/src/kernels/RedbackChemEndo.C
+++ b/src/kernels/RedbackChemEndo.C
@@ -12,6 +12,8 @@
 
 #include "RedbackChemEndo.h"
 
+registerMooseObject("RedbackApp", RedbackChemEndo);
+
 template <>
 InputParameters
 validParams<RedbackChemEndo>()

--- a/src/kernels/RedbackChemExo.C
+++ b/src/kernels/RedbackChemExo.C
@@ -12,6 +12,8 @@
 
 #include "RedbackChemExo.h"
 
+registerMooseObject("RedbackApp", RedbackChemExo);
+
 template <>
 InputParameters
 validParams<RedbackChemExo>()

--- a/src/kernels/RedbackChemPressure.C
+++ b/src/kernels/RedbackChemPressure.C
@@ -12,6 +12,8 @@
 
 #include "RedbackChemPressure.h"
 
+registerMooseObject("RedbackApp", RedbackChemPressure);
+
 template <>
 InputParameters
 validParams<RedbackChemPressure>()

--- a/src/kernels/RedbackDamage.C
+++ b/src/kernels/RedbackDamage.C
@@ -12,6 +12,8 @@
 
 #include "RedbackDamage.h"
 
+registerMooseObject("RedbackApp", RedbackDamage);
+
 template <>
 InputParameters
 validParams<RedbackDamage>()

--- a/src/kernels/RedbackFluidDivergence.C
+++ b/src/kernels/RedbackFluidDivergence.C
@@ -1,18 +1,18 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
 #include "RedbackFluidDivergence.h"
+
+registerMooseObject("RedbackApp", RedbackFluidDivergence);
 
 template <>
 InputParameters

--- a/src/kernels/RedbackFluidStressDivergenceTensors.C
+++ b/src/kernels/RedbackFluidStressDivergenceTensors.C
@@ -1,7 +1,21 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
 #include "RedbackFluidStressDivergenceTensors.h"
 
 #include "ElasticityTensorTools.h"
 #include "Material.h"
+
+registerMooseObject("RedbackApp", RedbackFluidStressDivergenceTensors);
 
 template <>
 InputParameters

--- a/src/kernels/RedbackMassConvection.C
+++ b/src/kernels/RedbackMassConvection.C
@@ -12,6 +12,8 @@
 
 #include "RedbackMassConvection.h"
 
+registerMooseObject("RedbackApp", RedbackMassConvection);
+
 template <>
 InputParameters
 validParams<RedbackMassConvection>()

--- a/src/kernels/RedbackMassDiffusion.C
+++ b/src/kernels/RedbackMassDiffusion.C
@@ -12,6 +12,8 @@
 
 #include "RedbackMassDiffusion.h"
 
+registerMooseObject("RedbackApp", RedbackMassDiffusion);
+
 template <>
 InputParameters
 validParams<RedbackMassDiffusion>()

--- a/src/kernels/RedbackMechDissip.C
+++ b/src/kernels/RedbackMechDissip.C
@@ -12,6 +12,8 @@
 
 #include "RedbackMechDissip.h"
 
+registerMooseObject("RedbackApp", RedbackMechDissip);
+
 template <>
 InputParameters
 validParams<RedbackMechDissip>()

--- a/src/kernels/RedbackNavier.C
+++ b/src/kernels/RedbackNavier.C
@@ -1,18 +1,18 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
 #include "RedbackNavier.h"
+
+registerMooseObject("RedbackApp", RedbackNavier);
 
 template <>
 InputParameters

--- a/src/kernels/RedbackPoromechanics.C
+++ b/src/kernels/RedbackPoromechanics.C
@@ -12,6 +12,8 @@
 
 #include "RedbackPoromechanics.h"
 
+registerMooseObject("RedbackApp", RedbackPoromechanics);
+
 template <>
 InputParameters
 validParams<RedbackPoromechanics>()

--- a/src/kernels/RedbackStressDivergenceTensors.C
+++ b/src/kernels/RedbackStressDivergenceTensors.C
@@ -15,6 +15,8 @@
 #include "ElasticityTensorTools.h"
 #include "Material.h"
 
+registerMooseObject("RedbackApp", RedbackStressDivergenceTensors);
+
 template <>
 InputParameters
 validParams<RedbackStressDivergenceTensors>()

--- a/src/kernels/RedbackThermalConvection.C
+++ b/src/kernels/RedbackThermalConvection.C
@@ -12,6 +12,8 @@
 
 #include "RedbackThermalConvection.h"
 
+registerMooseObject("RedbackApp", RedbackThermalConvection);
+
 template <>
 InputParameters
 validParams<RedbackThermalConvection>()

--- a/src/kernels/RedbackThermalDiffusion.C
+++ b/src/kernels/RedbackThermalDiffusion.C
@@ -12,6 +12,8 @@
 
 #include "RedbackThermalDiffusion.h"
 
+registerMooseObject("RedbackApp", RedbackThermalDiffusion);
+
 template <>
 InputParameters
 validParams<RedbackThermalDiffusion>()

--- a/src/kernels/RedbackThermalPressurization.C
+++ b/src/kernels/RedbackThermalPressurization.C
@@ -12,6 +12,8 @@
 
 #include "RedbackThermalPressurization.h"
 
+registerMooseObject("RedbackApp", RedbackThermalPressurization);
+
 template <>
 InputParameters
 validParams<RedbackThermalPressurization>()

--- a/src/kernels/RedbackVariableEqualsFunction.C
+++ b/src/kernels/RedbackVariableEqualsFunction.C
@@ -1,19 +1,19 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
 #include "Function.h"
 #include "RedbackVariableEqualsFunction.h"
+
+registerMooseObject("RedbackApp", RedbackVariableEqualsFunction);
 
 template <>
 InputParameters

--- a/src/materials/ComputePlasticStrainRate.C
+++ b/src/materials/ComputePlasticStrainRate.C
@@ -1,11 +1,18 @@
 /****************************************************************/
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*          All contents are licensed under LGPL V2.1           */
-/*             See LICENSE for full restrictions                */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
 #include "ComputePlasticStrainRate.h"
+
+registerMooseObject("RedbackApp", ComputePlasticStrainRate);
 
 template <>
 InputParameters

--- a/src/materials/ImageProcessing.C
+++ b/src/materials/ImageProcessing.C
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
@@ -15,6 +13,8 @@
 #include "Function.h"
 #include "ImageProcessing.h"
 #include <fstream>
+
+registerMooseObject("RedbackApp", ImageProcessing);
 
 template <>
 InputParameters

--- a/src/materials/RedbackFluidMaterial.C
+++ b/src/materials/RedbackFluidMaterial.C
@@ -1,18 +1,18 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
 #include "RedbackFluidMaterial.h"
+
+registerMooseObject("RedbackApp", RedbackFluidMaterial);
 
 template <>
 InputParameters

--- a/src/materials/RedbackMaterial.C
+++ b/src/materials/RedbackMaterial.C
@@ -13,6 +13,8 @@
 #include "Function.h"
 #include "RedbackMaterial.h"
 
+registerMooseObject("RedbackApp", RedbackMaterial);
+
 template <>
 InputParameters
 validParams<RedbackMaterial>()

--- a/src/materials/RedbackMechMaterialCC.C
+++ b/src/materials/RedbackMechMaterialCC.C
@@ -14,6 +14,8 @@
 #include "RedbackMechMaterialCC.h"
 #include <cmath> //used for fabs
 
+registerMooseObject("RedbackApp", RedbackMechMaterialCC);
+
 template <>
 InputParameters
 validParams<RedbackMechMaterialCC>()

--- a/src/materials/RedbackMechMaterialCCanisotropic.C
+++ b/src/materials/RedbackMechMaterialCCanisotropic.C
@@ -14,6 +14,8 @@
 #include "RedbackMechMaterialCCanisotropic.h"
 #include <cmath> //used for fabs
 
+registerMooseObject("RedbackApp", RedbackMechMaterialCCanisotropic);
+
 template <>
 InputParameters
 validParams<RedbackMechMaterialCCanisotropic>()

--- a/src/materials/RedbackMechMaterialDP.C
+++ b/src/materials/RedbackMechMaterialDP.C
@@ -12,6 +12,8 @@
 
 #include "RedbackMechMaterialDP.h"
 
+registerMooseObject("RedbackApp", RedbackMechMaterialDP);
+
 template <>
 InputParameters
 validParams<RedbackMechMaterialDP>()

--- a/src/materials/RedbackMechMaterialElastic.C
+++ b/src/materials/RedbackMechMaterialElastic.C
@@ -12,6 +12,8 @@
 
 #include "RedbackMechMaterialElastic.h"
 
+registerMooseObject("RedbackApp", RedbackMechMaterialElastic);
+
 template <>
 InputParameters
 validParams<RedbackMechMaterialElastic>()

--- a/src/materials/RedbackMechMaterialExpCC.C
+++ b/src/materials/RedbackMechMaterialExpCC.C
@@ -14,6 +14,8 @@
 #include "RedbackMechMaterialExpCC.h"
 #include <cmath> //used for fabs
 
+registerMooseObject("RedbackApp", RedbackMechMaterialExpCC);
+
 template <>
 InputParameters
 validParams<RedbackMechMaterialExpCC>()

--- a/src/materials/RedbackMechMaterialJ2.C
+++ b/src/materials/RedbackMechMaterialJ2.C
@@ -12,6 +12,8 @@
 
 #include "RedbackMechMaterialJ2.h"
 
+registerMooseObject("RedbackApp", RedbackMechMaterialJ2);
+
 template <>
 InputParameters
 validParams<RedbackMechMaterialJ2>()

--- a/src/meshmodifiers/ElementFileSubdomain.C
+++ b/src/meshmodifiers/ElementFileSubdomain.C
@@ -1,13 +1,11 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
@@ -15,6 +13,8 @@
 #include "ElementFileSubdomain.h"
 #include "MooseMesh.h"
 #include <fstream>
+
+registerMooseObject("RedbackApp", ElementFileSubdomain);
 
 template <>
 InputParameters

--- a/src/postprocessors/RankTwoScalarPostprocessor.C
+++ b/src/postprocessors/RankTwoScalarPostprocessor.C
@@ -1,18 +1,19 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
+
 #include "RankTwoScalarPostprocessor.h"
 #include "RankTwoScalarTools.h"
+
+registerMooseObject("RedbackApp", RankTwoScalarPostprocessor);
 
 template <>
 InputParameters

--- a/src/scalarkernels/RedbackContinuation.C
+++ b/src/scalarkernels/RedbackContinuation.C
@@ -12,10 +12,8 @@
 
 #include "RedbackContinuation.h"
 
-/**
- * This function defines the valid parameters for
- * this Kernel and their default values
- */
+registerMooseObject("RedbackApp", RedbackContinuation);
+
 template <>
 InputParameters
 validParams<RedbackContinuation>()

--- a/src/timesteppers/ReturnMapIterDT.C
+++ b/src/timesteppers/ReturnMapIterDT.C
@@ -1,18 +1,18 @@
 /****************************************************************/
 /*               DO NOT MODIFY THIS HEADER                      */
-/* MOOSE - Multiphysics Object Oriented Simulation Environment  */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
 /*                                                              */
-/*           (c) 2010 Battelle Energy Alliance, LLC             */
+/*              (c) 2014 CSIRO and UNSW Australia               */
 /*                   ALL RIGHTS RESERVED                        */
 /*                                                              */
-/*          Prepared by Battelle Energy Alliance, LLC           */
-/*            Under Contract No. DE-AC07-05ID14517              */
-/*            With the U. S. Department of Energy               */
+/*            Prepared by CSIRO and UNSW Australia              */
 /*                                                              */
 /*            See COPYRIGHT for full restrictions               */
 /****************************************************************/
 
 #include "ReturnMapIterDT.h"
+
+registerMooseObject("RedbackApp", ReturnMapIterDT);
 
 template <>
 InputParameters

--- a/src/utils/Ellipse.C
+++ b/src/utils/Ellipse.C
@@ -1,3 +1,14 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*     REDBACK - Rock mEchanics with Dissipative feedBACKs      */
+/*                                                              */
+/*              (c) 2014 CSIRO and UNSW Australia               */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*            Prepared by CSIRO and UNSW Australia              */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
 /**
  * Utilities to deal with ellipses for modified Cam-Clay model.
  * Code for distance point-ellipse from Geometric Tools LLC, Redmond WA 98052


### PR DESCRIPTION
updated inconsistent copyright headers in all files

Following "App Object/Action Registration Changes" mentioned in MOOSE Oct 2018 newsletter 