### PR TITLE
Update interface tests for named block-pair boundaries

### DIFF
--- a/tests/interface_flow/interface_darcy_grav_test.i
+++ b/tests/interface_flow/interface_darcy_grav_test.i
@@ -8,7 +8,6 @@ gravity = '0.56 0.98 0'
   [break]
     type = BreakMeshByBlockGenerator
     input = file
-    split_interface = false
   []
 []
 
@@ -34,7 +33,7 @@ gravity = '0.56 0.98 0'
     type = InterfaceDarcy
     variable = p
     neighbor_var = p
-    boundary = interface
+    boundary = left_block_right_block
     fault_lewis_number = lewis_fault
     fault_thickness = 0.1
   []
@@ -75,7 +74,7 @@ gravity = '0.56 0.98 0'
   [p_left]
     type = SideAverageValue
     variable = p
-    boundary = interface
+    boundary = left_block_right_block
   []
 []
 

--- a/tests/interface_flow/interface_darcy_test.i
+++ b/tests/interface_flow/interface_darcy_test.i
@@ -16,7 +16,6 @@
   [./break]
     type = BreakMeshByBlockGenerator
     input = file
-    split_interface = false
   [../]
 []
 
@@ -42,7 +41,7 @@
     type = InterfaceDarcy
     variable = p
     neighbor_var = p
-    boundary = interface
+    boundary = Block0_Block1
     fault_lewis_number = lewis_fault
     fault_thickness = 0.1
   []

--- a/tests/interface_flow/tests
+++ b/tests/interface_flow/tests
@@ -4,13 +4,11 @@
     rel_err = 1e-8
     input = 'interface_darcy_test.i'
     csvdiff = 'interface_darcy_test.csv'
-    skip = "Waiting to reconcile with MOOSE PR#32309"
   [../]
   [./test_interface_flow_gravity]
     type = 'CSVDiff'
     rel_err = 6e-2
     input = 'interface_darcy_grav_test.i'
     csvdiff = 'interface_darcy_grav_test.csv'
-    skip = "Waiting to reconcile with MOOSE PR#32309"
   [../]
 []

--- a/tests/interface_mech/compression_angled_interface.i
+++ b/tests/interface_mech/compression_angled_interface.i
@@ -6,7 +6,6 @@
   [break]
     type = BreakMeshByBlockGenerator
     input = file
-    split_interface = false
   []
   [bottom_corner]
     type = ExtraNodesetGenerator
@@ -46,7 +45,7 @@
     variable = disp_x
     neighbor_var = disp_x
     penalty = 1e6
-    boundary = interface
+    boundary = top_block_bottom_block
     tangent_jump = 2e-5
     component = 0
   []
@@ -55,7 +54,7 @@
     variable = disp_y
     neighbor_var = disp_y
     penalty = 1e6
-    boundary = interface
+    boundary = top_block_bottom_block
     tangent_jump = 2e-5
     component = 1
   []
@@ -94,7 +93,7 @@
 [Functions]
   [loading_vel]
     type = ParsedFunction
-    value = '-0.0002*t'
+    expression = '-0.0002*t'
   []
 []
 

--- a/tests/interface_mech/compression_interface.i
+++ b/tests/interface_mech/compression_interface.i
@@ -16,7 +16,6 @@
   [break]
     type = BreakMeshByBlockGenerator
     input = file
-    split_interface = false
   []
 []
 
@@ -50,7 +49,7 @@
     variable = disp_x
     neighbor_var = disp_x
     penalty = 1e6
-    boundary = interface
+    boundary = Block0_Block1
     component = 0
   []
   [interfacey]
@@ -58,7 +57,7 @@
     variable = disp_y
     neighbor_var = disp_y
     penalty = 1e6
-    boundary = interface
+    boundary = Block0_Block1
     component = 1
   []
 []
@@ -96,7 +95,7 @@
 [Functions]
   [loading_vel]
     type = ParsedFunction
-    value = '0.0002*t'
+    expression = '0.0002*t'
   []
 []
 

--- a/tests/interface_mech/compression_interface_pressure.i
+++ b/tests/interface_mech/compression_interface_pressure.i
@@ -16,7 +16,6 @@
   [break]
     type = BreakMeshByBlockGenerator
     input = file
-    split_interface = false
   []
 []
 
@@ -52,7 +51,7 @@
     variable = disp_x
     neighbor_var = disp_x
     penalty = 1e6
-    boundary = interface
+    boundary = Block0_Block1
     component = 0
   []
   [interfacey]
@@ -60,7 +59,7 @@
     variable = disp_y
     neighbor_var = disp_y
     penalty = 1e6
-    boundary = interface
+    boundary = Block0_Block1
     component = 1
   []
 []
@@ -119,7 +118,7 @@
 [Functions]
   [loading_vel]
     type = ParsedFunction
-    value = '0.0002*t'
+    expression = '0.0002*t'
   []
 []
 

--- a/tests/interface_mech/tests
+++ b/tests/interface_mech/tests
@@ -4,24 +4,20 @@
     type = 'Exodiff'
     input = 'compression_interface.i'
     exodiff = 'compression_interface.e'
-    skip = "Waiting to reconcile with MOOSE PR#32309"
   [../]
   [./test_interface_poromech]
     type = 'Exodiff'
     input = 'compression_interface_pressure.i'
     exodiff = 'compression_interface_pressure.e'
-    skip = "Waiting to reconcile with MOOSE PR#32309"
   [../]
   [./test_angled_interface_mech]
     type = 'Exodiff'
     input = 'compression_angled_interface.i'
     exodiff = 'compression_angled_interface.e'
-    skip = "Waiting to reconcile with MOOSE PR#32309"
   [../]
   [./test_traction_auxkernel]
     type = 'Exodiff'
     input = 'testTractionProjectionAux.i'
     exodiff = 'testTractionProjectionAux.e'
-    skip = "Waiting to reconcile with MOOSE PR#32309"
   [../]
 []


### PR DESCRIPTION
Resolves idaholab/moose/issues/33062

This updates REDBACK interface tests for the current `BreakMeshByBlockGenerator`(BMBB) behavior after the MOOSE changes discussed in idaholab/moose#32199. To be more specific, these test file changes are related to the recent MOOSE changes for BMBB in idaholab/moose#32309.

The old tests used `split_interface = false` and applied interface kernels on the generic `interface` boundary. With the current generator behavior, the interface kernels need to target the generated block-pair boundaries, such as `Block0_Block1`, `left_block_right_block`, or `top_block_bottom_block`.

  ## Changes
  
  - Removed `split_interface = false` from `BreakMeshByBlockGenerator` interface tests.
  - Updated interface kernel boundaries to the generated named block-pair boundaries.